### PR TITLE
feat: harden path and filename validation

### DIFF
--- a/src/__tests__/transform.test.ts
+++ b/src/__tests__/transform.test.ts
@@ -92,6 +92,11 @@ test('toYamlChunks generates individual YAML files', () => {
   expect(chunks['Policy_One']).toContain('critical: false');
 });
 
+test('toYamlChunks rejects policy names with null bytes', () => {
+  const policies = [{ name: 'bad\0name', query: 'SELECT 1' }];
+  expect(() => toYamlChunks(policies)).toThrow('Invalid policy name');
+});
+
 test('rawYamlToList handles basic YAML array', () => {
   const yaml = `
 - name: Policy 1

--- a/src/__tests__/writer.test.ts
+++ b/src/__tests__/writer.test.ts
@@ -12,6 +12,13 @@ test('outputPath generates correct file paths', () => {
   expect(outputPath('ubuntu', './test')).toBe(join('./test', 'cis-benchmark-ubuntu.yml'));
 });
 
+test('outputPath rejects dangerous folder names', () => {
+  expect(() => outputPath('../etc', './out')).toThrow('Invalid folder name');
+  expect(() => outputPath('bad/dir', './out')).toThrow('Invalid folder name');
+  expect(() => outputPath('bad\\dir', './out')).toThrow('Invalid folder name');
+  expect(() => outputPath('bad\0dir', './out')).toThrow('Invalid folder name');
+});
+
 test('write creates file with content', async () => {
   const testDir = './test-write';
   const testFile = join(testDir, 'test.yml');

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -177,6 +177,9 @@ export function toYamlChunks(items: SanitizedPolicyItem[]): Record<string, strin
   for (const item of items) {
     // Create a safe filename from the policy name
     const policyName = item.name || 'unknown';
+    if (policyName.includes('\0') || policyName.includes('\x00')) {
+      throw new Error('Invalid policy name contains null bytes');
+    }
     let safeName = policyName
       .replace(/\s+/g, '_')
       .replace(/[/\\]/g, '_')

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -17,9 +17,17 @@ import { dirname, join } from 'node:path';
  * ```
  */
 export function outputPath(folder: string, outDir: string): string {
+  validatePath(folder);
   const cleanFolder = folder.replace(/-/g, '');
   const filename = `cis-benchmark-${cleanFolder}.yml`;
   return join(outDir, filename);
+}
+
+function validatePath(folder: string): void {
+  const dangerous = ['..', '/', '\\', '\0', '\x00'];
+  if (dangerous.some(char => folder.includes(char))) {
+    throw new Error(`Invalid folder name contains dangerous characters: ${folder}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- validate folder names in output paths to block path traversal characters
- reject policy names containing null bytes before writing YAML
- cover invalid path and policy names with new unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ee4d2ca248325bd3e0a8d7a00f4f8