### PR TITLE
feat: read CLI version dynamically from package.json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,11 +11,12 @@ import { rawYamlToList, sanitizeAll, filterByLevel, toYaml, toYamlChunks } from 
 import { outputPath, write } from './writer.js';
 import { join } from 'node:path';
 import { mkdir } from 'node:fs/promises';
+import packageJson from '../package.json' with { type: 'json' };
 
 const program = new Command();
 
-// Package version - in a real setup this would come from package.json
-const VERSION = '0.1.0';
+// Read version dynamically from package.json
+const VERSION = packageJson.version;
 
 program
   .name('cis-to-fleet')


### PR DESCRIPTION
## Summary
- Replace hardcoded VERSION constant with dynamic import from package.json
- Use ES module import assertion to load package.json at build time
- Ensures CLI version stays in sync with package version automatically

## Changes
- **src/cli.ts**: Updated to import version from `../package.json` using ES module import assertion
- Removed hardcoded `VERSION = '0.1.0'` constant
- Added dynamic version reading: `const VERSION = packageJson.version`

## Testing
- ✅ All existing tests pass (15/15)
- ✅ `--version` flag displays correct version (0.1.0)
- ✅ Build process works correctly with ES module imports
- ✅ CLI functionality verified working (list command tested)
- ✅ Both development (`bun run src/cli.ts`) and built (`node dist/cli.js`) versions work

## Closes
Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)